### PR TITLE
Fix small issue with observation 'state' dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please cite us if you use FFAI in your publications.
   * No inducements
   * No timers; Players have unlimited time each turn
 * A web interface supporting:
-  * Hot-seat 
+  * Hot-seat
   * Online play
   * Spectators
   * Human vs. bot
@@ -38,7 +38,7 @@ Please cite us if you use FFAI in your publications.
   * Kick-off table enabled/disabled
   * Which scatter dice to use
   * ...
-* Premade formations to ease the setup phase. Custom made formations can easily be implemented. 
+* Premade formations to ease the setup phase. Custom made formations can easily be implemented.
 * Games can be saved and loaded
 
 ## Plans for Future Releases
@@ -64,14 +64,14 @@ Go to: http://127.0.0.1:5000/
 The main page lists active games. For each active game you can click on a team to play it. If a team is disabled it is controlled by a bot and cannot be selected. Click hot-seat to play human vs. human on the same machine.
 
 ## Create a Bot
-To make you own bot you must implement the Agent class and its three methods: new_game, act, and end_game which are called by the framework. The act method must return an instance of the Action class. 
+To make you own bot you must implement the Agent class and its three methods: new_game, act, and end_game which are called by the framework. The act method must return an instance of the Action class.
 
 Take a look at our [bot_example.py](examples/bot_example.py).
 
 Be aware, that you shouldn't modify instances that comes from the framework such as Square instances as these are shared with the GameState instance in FFAI. In future releases, we plan to release an AI tournament module that will clone the instances before they are handed to the bots. For now, this is up to the user to do.
 
 ## Gym Interface
-FFAI implements the Open AI Gym interace for easy integration of machine learning algorithms. 
+FFAI implements the Open AI Gym interace for easy integration of machine learning algorithms.
 
 Take a look at our [gym_example.py](examples/gym_example.py).
 
@@ -152,7 +152,7 @@ The 44 default normalized values in obs['state'] are:
 4. 'nice'
 5. 'pouring rain'
 6. 'blizzard'
-7. 'own turn'
+7. 'own active'
 8. 'kicking first half'
 9. 'kicking this drive'
 10. 'own reserves'

--- a/ffai/ai/env.py
+++ b/ffai/ai/env.py
@@ -241,7 +241,7 @@ class FFAIEnv(gym.Env):
         obs['state']['pouring rain'] = 1.0 if game.state.weather.value == WeatherType.POURING_RAIN else 0.0
         obs['state']['blizzard'] = 1.0 if game.state.weather.value == WeatherType.BLIZZARD else 0.0
 
-        obs['state']['own turn'] = 1.0 if game.state.current_team == active_team else 0.0
+        obs['state']['own active'] = 1.0 if game.state.current_team == active_team else 0.0
         obs['state']['kicking first half'] = 1.0 if game.state.kicking_first_half == active_team else 0.0
         obs['state']['kicking this drive'] = 1.0 if game.state.kicking_this_drive == active_team else 0.0
         obs['state']['own reserves'] = len(game.get_reserves(active_team)) / 16.0 if active_team is not None else 0.0


### PR DESCRIPTION
The observation state dictionary sets the key `own turn` twice, once to mean "is my team the currently active team?" and once to mean "how many turns has my team had?". The second version overwrites the first, unfortunately. This fix renames the "is my team the currently active team?" to `own active` so that both values can exist.