### PR TITLE
Include player actions as valid in env

### DIFF
--- a/ffai/ai/env.py
+++ b/ffai/ai/env.py
@@ -162,7 +162,10 @@ class FFAIEnv(gym.Env):
             'procedure':  spaces.Box(low=0, high=1, shape=(len(FFAIEnv.procedures),)),
         })
 
-        self.actions = FFAIEnv.simple_action_types + FFAIEnv.positional_action_types + FFAIEnv.formation_action_types
+        self.actions = (
+            FFAIEnv.simple_action_types + FFAIEnv.positional_action_types +
+            FFAIEnv.formation_action_types + FFAIEnv.player_action_types[3:]
+        )
 
         self.action_space = spaces.Dict({
             'action-type': spaces.Discrete(len(self.actions)),


### PR DESCRIPTION
I'm not positive about this one because I am still trying to fully wrap my head around this code. 

When I try to run an episode with the `gym` version with a random choice algorithm, the players don't do anything. I've done some digging and I think it's because they are only presented with the `END_TURN` action. And I _think_ that is because these `START_MOVE`, `START_BLOCK`, `START_BLITZ`, `START_PASS`, `START_FOUL`, and `START_HANDOFF` moves are not being presented as valid actions.