### PR TITLE
correct some  rules issues (Tackle and Dodge, Apothecary with KO)

### DIFF
--- a/ffai/core/model.py
+++ b/ffai/core/model.py
@@ -448,19 +448,19 @@ class Pitch:
         diving_tacklers = []
         shadowers = []
         tentaclers = []
-        for square in self.adjacent_player_squares(player.position, include_own=False, include_opp=True):
+        for square in self.adjacent_player_squares(player, include_own=False, include_opp=True):
             player_at = self.get_player_at(square)
             if player_at is not None and player_at.has_tackle_zone():
                 tackle_zones += 1
-            if player_at is None and player_at.has_skill(Skill.TACKLE):
+            if player_at is not None and player_at.has_skill(Skill.TACKLE):
                 tacklers.append(player_at)
-            if player_at is None and player_at.has_skill(Skill.PREHENSILE_TAIL):
+            if player_at is not None and player_at.has_skill(Skill.PREHENSILE_TAIL):
                 prehensile_tailers.append(player_at)
-            if player_at is None and player_at.has_skill(Skill.DIVING_TACKLE):
+            if player_at is not None and player_at.has_skill(Skill.DIVING_TACKLE):
                 diving_tacklers.append(player_at)
-            if player_at is None and player_at.has_skill(Skill.SHADOWING):
+            if player_at is not None and player_at.has_skill(Skill.SHADOWING):
                 shadowers.append(player_at)
-            if player_at is None and player_at.has_skill(Skill.TENTACLES):
+            if player_at is not None and player_at.has_skill(Skill.TENTACLES):
                 tentaclers.append(player_at)
 
         return tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers
@@ -616,7 +616,7 @@ class Pitch:
                     continue
                 if player_at.team == passer.team:
                     continue
-                if player_at.can_catch():
+                if not player_at.can_catch():
                     continue
                 if player_at.has_skill(Skill.NO_HANDS):
                     continue


### PR DESCRIPTION
I found several minor errors which are corrected in this branch:

- a wrong condition to test is a play can catch or not
- a list of wrong conditions to test if an adjacent player with some skill exists or not
- when someone use an Apothecary on a KO, the player is still on the pitch but stunned (instead of being put on reserve)
- Tackle was not considered for dodge and block results

I have also done two minor changes and I hope it doesn't break anything:
- I change the order between WeatherTable and Fans procedure
- During Setup, I modify the setup reorganization