### PR TITLE
Fix Game random seed

### DIFF
--- a/ffai/core/game.py
+++ b/ffai/core/game.py
@@ -13,7 +13,6 @@ from copy import deepcopy
 import numpy as np
 import multiprocessing
 import pickle
-import random
 
 
 class Game:
@@ -31,8 +30,7 @@ class Game:
         self.config = config
         self.ruleset = get_rule_set(config.ruleset) if ruleset is None else ruleset
         self.state = state if state is not None else GameState(self, deepcopy(home_team), deepcopy(away_team))
-        self.seed = random.seed(a=seed, version=2)
-        self.rnd = np.random.RandomState(self.seed)
+        self.rnd = np.random.RandomState(seed)
 
         self.start_time = None
         self.end_time = None


### PR DESCRIPTION
Hi, I think there is a bug there :
https://github.com/njustesen/ffai/blob/b0780ab68078fe8c9333394a2485e2905e75b478/ffai/core/game.py#L34-L35
random.seed is a function which doesn't return anything, so Numpy use None instead of the seed in parameter.

Here are some reproduction steps:
``` python
>>> seed = 3
>>> new_seed = random.seed(a=seed, version=2)
>>> rnd1 = np.random.RandomState(new_seed)
>>> rnd2 = np.random.RandomState(new_seed)
>>> rnd1.randint(0,1000)
589
>>> rnd2.randint(0,1000)
128
```

I removed `import random` and `random.seed`, since I don't see any other usage in this file, but if setting the seed there was needed for `random` usage in other files, it should be added back (without return value):
``` python
        random.seed(a=seed, version=2)
        self.rnd = np.random.RandomState(seed)
```