### PR TITLE
Fix bothelper.squares_within for index

### DIFF
--- a/ffai/util/bothelper.py
+++ b/ffai/util/bothelper.py
@@ -388,7 +388,7 @@ def squares_within(game: g.Game, square: m.Square, distance: int) -> List[m.Squa
     squares: List[m.Square] = []
     for i in range(-distance, distance+1):
         for j in range(-distance, distance+1):
-            cur_square = game.state.pitch.get_square(square.x+i, square.y+i)
+            cur_square = game.state.pitch.get_square(square.x+i, square.y+j)
             if cur_square != square and not game.state.pitch.is_out_of_bounds(cur_square):
                 squares.append(cur_square)
     return squares


### PR DESCRIPTION
There was an error in the usage (or lack thereof) of the j loop index in bothelper.squares.

Reproduction step:
``` python
import ffai.core.game as g
import ffai.core.model as m
import ffai.util.bothelper as bh
config = g.get_config("ff-11-bot-bowl-i.json")
ruleset = g.get_rule_set(config.ruleset, all_rules=False)
home = g.get_team_by_id("human-1", ruleset)
away = g.get_team_by_id("human-2", ruleset)
game = g.Game(1, home, away, None, None, config)
[(sq.x, sq.y) for sq in bh.squares_within(game, m.Square(3,10), 1)]
```
Before fix, it returned `[(2, 9), (2, 9), (2, 9), (4, 11), (4, 11), (4, 11)]`.
After fix, it's `[(2, 9), (2, 10), (2, 11), (3, 9), (3, 11), (4, 9), (4, 10), (4, 11)]`.
