### PR TITLE
Tests and minor fix for Mighty Blow

### DIFF
--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -148,10 +148,8 @@ class Armor(Procedure):
             # Armor broken
             if result >= roll.target:
                 armor_broken = True
-
-            # Armor broken - Might Blow
-            if self.inflictor is not None and self.inflictor.has_skill(Skill.MIGHTY_BLOW) \
-                    and result + 1 > self.player.get_av():
+            elif result == roll.target -1 and self.inflictor is not None and self.inflictor.has_skill(Skill.MIGHTY_BLOW):
+                # only use mighty_blow if it makes the armour break
                 roll.modifiers += 1
                 armor_broken = True
                 mighty_blow_used = True

--- a/tests/test_armor.py
+++ b/tests/test_armor.py
@@ -1,0 +1,76 @@
+import pytest
+from ffai.core.game import *
+from unittest.mock import *
+import numpy as np
+
+@patch("ffai.core.game.Game")
+def test_armour_with_mighty_blow(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 4+5 = 9 -> not broken without MB
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(4)
+        D6.FixedRolls.append(5)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc")
+        blocker = Player("1", role, "test", 1, "orc", extra_skills=[Skill.MIGHTY_BLOW])
+        arm = Armor(mock_game, player, inflictor=blocker)
+        arm.step(action=None)
+        
+        # mighty blow makes armour broken (10)
+        proc = stack.peek()
+        assert isinstance(proc, Injury)
+        assert proc.mighty_blow_used == True # indicate MB can't be used in Injury roll
+
+@patch("ffai.core.game.Game")
+def test_armour_broken_with_mighty_blow_unused(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 5+5 = 10 -> broken without MB
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(5)
+        D6.FixedRolls.append(6)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc")
+        blocker = Player("1", role, "test", 1, "orc", extra_skills=[Skill.MIGHTY_BLOW])
+        arm = Armor(mock_game, player, inflictor=blocker)
+        arm.step(action=None)
+        
+        # armour broken (10)
+        proc = stack.peek()
+        assert isinstance(proc, Injury)
+        assert proc.mighty_blow_used == False # indicate MB can be used in Injury roll
+
+@patch("ffai.core.game.Game")
+def test_armour_no_break(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 4+5 = 9 -> not broken without MB
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(4)
+        D6.FixedRolls.append(5)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc")
+        blocker = Player("1", role, "test", 1, "orc")
+        arm = Armor(mock_game, player, inflictor=blocker)
+        arm.step(action=None)
+        
+        # NO mighty blow so proc is still Armor for unbroken
+        proc = stack.peek()
+        assert isinstance(proc, Armor)
+

--- a/tests/test_injury.py
+++ b/tests/test_injury.py
@@ -1,0 +1,147 @@
+import pytest
+from ffai.core.game import *
+from unittest.mock import *
+import numpy as np
+
+@patch("ffai.core.game.Game")
+def test_injury_default_stunned(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 3+4 = 7 => Stunned
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(3)
+        D6.FixedRolls.append(4)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc")
+        blocker = Player("1", role, "test", 1, "orc")
+        injury = Injury(mock_game, player, inflictor=blocker)
+        injury.step(action=None)
+        
+        # NO mighty blow so proc is still Injury for stunned result
+        proc = stack.peek()
+        assert isinstance(proc, Injury)
+
+@patch("ffai.core.game.Game")
+def test_injury_default_casualty(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 3+6 = 9 => KO
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(3)
+        D6.FixedRolls.append(6)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc")
+        blocker = Player("1", role, "test", 1, "orc")
+        injury = Injury(mock_game, player, inflictor=blocker)
+        injury.step(action=None)
+        
+        # NO mighty blow so proc is still Injury for stunned result
+        proc = stack.peek()
+        assert isinstance(proc, KnockOut)
+
+
+@patch("ffai.core.game.Game")
+def test_injury_with_mighty_blow(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 3+4 = 7 => Stunned
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(3)
+        D6.FixedRolls.append(4)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc")
+        blocker = Player("1", role, "test", 1, "orc", extra_skills=[Skill.MIGHTY_BLOW])
+        injury = Injury(mock_game, player, inflictor=blocker)
+        injury.step(action=None)
+        
+        # mighty blow should make it a KO
+        proc = stack.peek()
+        assert isinstance(proc, KnockOut)
+
+
+@patch("ffai.core.game.Game")
+def test_injury_with_mighty_blow_used(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 3+4 = 7 => Stunned
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(3)
+        D6.FixedRolls.append(4)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc")
+        blocker = Player("1", role, "test", 1, "orc", extra_skills=[Skill.MIGHTY_BLOW])
+        injury = Injury(mock_game, player, inflictor=blocker, mighty_blow_used=True)
+        injury.step(action=None)
+        
+        # can't use mighty blow again, so should still be Injury for Stunned result
+        proc = stack.peek()
+        assert isinstance(proc, Injury)
+
+
+@patch("ffai.core.game.Game")
+def test_injury_stunned_with_stunty(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 3+4 = 7 => KO for stunty
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(3)
+        D6.FixedRolls.append(4)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.STUNTY])
+        blocker = Player("1", role, "test", 1, "orc")
+        injury = Injury(mock_game, player, inflictor=blocker)
+        injury.step(action=None)
+        
+        # stunty should make it a KO
+        proc = stack.peek()
+        assert isinstance(proc, KnockOut)
+
+@patch("ffai.core.game.Game")
+def test_injury_ko_with_stunty(mock_game):
+    # patch the mock game proc stack
+    stack = Stack()
+    mock_game.state.stack = stack    
+    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
+        a.return_value=stack
+
+        # fix the dice rolls - 3+6 = 9 => CAS for stunty
+        D6.FixedRolls.clear()
+        D6.FixedRolls.append(3)
+        D6.FixedRolls.append(6)
+
+        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
+        player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.STUNTY])
+        blocker = Player("1", role, "test", 1, "orc")
+        injury = Injury(mock_game, player, inflictor=blocker)
+        injury.step(action=None)
+        
+        # stunty should make it a Casualty
+        proc = stack.peek()
+        assert isinstance(proc, Casualty)
+
+


### PR DESCRIPTION
Added some tests for MB under injury and armour.
It turned out that mighty blow was being applied even when the roll doesn't require it, meaning it wasn't usable in armour rolls.
Fixed!