### PR TITLE
Adding prehensile tail to the dodge modifiers

### DIFF
--- a/ffai/core/model.py
+++ b/ffai/core/model.py
@@ -588,28 +588,7 @@ class Pitch:
         return tackle_zones
 
     def get_tackle_zones_detailed(self, player):
-        tackle_zones = 0
-        tacklers = []
-        prehensile_tailers = []
-        diving_tacklers = []
-        shadowers = []
-        tentaclers = []
-        for square in self.get_adjacent_player_squares(player, include_own=False, include_opp=True):
-            player_at = self.get_player_at(square)
-            if player_at is not None and player_at.has_tackle_zone():
-                tackle_zones += 1
-            if player_at is not None and player_at.has_skill(Skill.TACKLE):
-                tacklers.append(player_at)
-            if player_at is not None and player_at.has_skill(Skill.PREHENSILE_TAIL):
-                prehensile_tailers.append(player_at)
-            if player_at is not None and player_at.has_skill(Skill.DIVING_TACKLE):
-                diving_tacklers.append(player_at)
-            if player_at is not None and player_at.has_skill(Skill.SHADOWING):
-                shadowers.append(player_at)
-            if player_at is not None and player_at.has_skill(Skill.TENTACLES):
-                tentaclers.append(player_at)
-
-        return tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers
+        return self.get_tackle_zones_detailed_at(player, player.position)
 
     def get_tackle_zones_detailed_at(self, player, position):
         tackle_zones = 0
@@ -632,7 +611,7 @@ class Pitch:
             if player_at is None and player_at.has_skill(Skill.TENTACLES):
                 tentaclers.append(player_at)
 
-        return tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers
+        return TackleZoneDetails(tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers)
 
     def get_players_blockable_at(self, player, position):
         blockable = []
@@ -1541,3 +1520,13 @@ class Formation:
                     actions.append(Action(ActionType.PLACE_PLAYER, pos=pos, player=player))
                     positions_used.append(pos)
         return actions
+
+
+class TackleZoneDetails:
+    def __init__(self, tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers):
+        self.tackle_zones = tackle_zones
+        self.tacklers = tacklers
+        self.prehensile_tailers = prehensile_tailers
+        self.diving_tacklers = diving_tacklers
+        self.shadowers = shadowers
+        self.tentaclers = tentaclers

--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -1493,7 +1493,7 @@ class Dodge(Procedure):
     success = [6, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1]
 
     @staticmethod
-    def dodge_modifiers(game, player, pos):
+    def dodge_modifiers(game, player, pos, detractors=None):
 
         modifiers = 1
         tackle_zones_to = game.num_tackle_zones_at(player, pos)
@@ -1507,6 +1507,11 @@ class Dodge(Procedure):
             ignore_opp_mods = True
         if player.has_skill(Skill.TWO_HEADS):
             modifiers += 1
+        
+        if detractors :
+            # see game.tackle_zones_in_detailed for magic numbers
+            if detractors[2]: 
+                modifiers -= len(detractors[2]) # subtract 1 for each prehensile tail detractor
 
         if not ignore_opp_mods:
             modifiers -= tackle_zones_to

--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -1493,7 +1493,7 @@ class Dodge(Procedure):
     success = [6, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1]
 
     @staticmethod
-    def dodge_modifiers(game, player, pos, detractors=None):
+    def dodge_modifiers(game, player, pos, tz_details=None):
 
         modifiers = 1
         tackle_zones_to = game.num_tackle_zones_at(player, pos)
@@ -1508,12 +1508,11 @@ class Dodge(Procedure):
         if player.has_skill(Skill.TWO_HEADS):
             modifiers += 1
 
-        if not detractors:
-            detractors = game.tackle_zones_in_detailed(player)
-        if detractors:
-            # see game.tackle_zones_in_detailed for magic numbers
-            if detractors[2]: 
-                modifiers -= len(detractors[2]) # subtract 1 for each prehensile tail detractor
+        if not tz_details:
+            tz_details = game.get_tackle_zones_detailed(player)
+        if tz_details:
+            if tz_details.prehensile_tailers:
+                modifiers -= len(tz_details.prehensile_tailers)  # subtract 1 for each prehensile tail detractor
 
         if not ignore_opp_mods:
             modifiers -= tackle_zones_to
@@ -1545,12 +1544,11 @@ class Dodge(Procedure):
 
             # Calculate target
             # we need tacklers later, so passing in result
-            detractors = self.game.tackle_zones_in_detailed(self.player)
+            tz_details = self.game.get_tackle_zones_detailed(self.player)
 
-            tacklers = self.game.get_tackle_zones_detailed(self.player)[1]
-            roll.modifiers = Dodge.dodge_modifiers(self.game, self.player, self.pos, detractors=detractors)
+            roll.modifiers = Dodge.dodge_modifiers(self.game, self.player, self.pos, tz_details=tz_details)
 
-            tacklers = detractors[1]
+            tacklers = tz_details.tacklers
 
             # Break tackle - use st instead of ag
             attribute = self.player.get_ag()

--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -1507,8 +1507,10 @@ class Dodge(Procedure):
             ignore_opp_mods = True
         if player.has_skill(Skill.TWO_HEADS):
             modifiers += 1
-        
-        if detractors :
+
+        if not detractors:
+            detractors = game.tackle_zones_in_detailed(player)
+        if detractors:
             # see game.tackle_zones_in_detailed for magic numbers
             if detractors[2]: 
                 modifiers -= len(detractors[2]) # subtract 1 for each prehensile tail detractor
@@ -1542,9 +1544,13 @@ class Dodge(Procedure):
             self.rolled = True
 
             # Calculate target
-            roll.modifiers = Dodge.dodge_modifiers(self.game, self.player, self.pos)
+            # we need tacklers later, so passing in result
+            detractors = self.game.tackle_zones_in_detailed(self.player)
 
             tacklers = self.game.get_tackle_zones_detailed(self.player)[1]
+            roll.modifiers = Dodge.dodge_modifiers(self.game, self.player, self.pos, detractors=detractors)
+
+            tacklers = detractors[1]
 
             # Break tackle - use st instead of ag
             attribute = self.player.get_ag()

--- a/tests/test_dodge.py
+++ b/tests/test_dodge.py
@@ -1,0 +1,44 @@
+import pytest
+from ffai.core.game import *
+from unittest.mock import *
+
+@patch("ffai.core.game.Game")
+def test_default_dodge_modifier(mock_game):
+    mock_game.num_tackle_zones_at.return_value = 0 # no tackle zones in target square
+
+    role = Role("Lineman", "orc", 6,3,3,9, [], 50000, None)
+    player = Player("1", role, "test", 1, "orc")
+
+    pos = Square(11,12)
+    # need to test static method to ensure calculation for lookahead requests
+    modifier = Dodge.dodge_modifiers(mock_game, player, pos)
+
+    assert modifier == 1
+
+
+@patch("ffai.core.game.Game")
+def test_prehensile_tail_modifier(mock_game):
+    mock_game.num_tackle_zones_at.return_value = 0 # no tackle zones in target square
+
+    role = Role("Lineman", "orc", 6,3,3,9, [], 50000, None)
+    player = Player("1", role, "test", 1, "orc")
+
+    # set up a detractor in square moving from
+    tail_player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.PREHENSILE_TAIL])
+    
+    pos = Square(11,12)
+    prehensile_tailers = [tail_player]
+    tackle_zones = 0
+
+    tacklers = []
+    # prehensile_tailers = []
+    diving_tacklers = []
+    shadowers = []
+    tentaclers = []
+
+    detractors = (tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers)
+
+    # need to test static method to ensure calculation for lookahead requests
+    modifier = Dodge.dodge_modifiers(mock_game, player, pos, detractors=detractors)
+
+    assert modifier == 0

--- a/tests/test_dodge.py
+++ b/tests/test_dodge.py
@@ -36,8 +36,8 @@ def test_prehensile_tail_modifier(mock_game):
     tail_player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.PREHENSILE_TAIL])
     prehensile_tailers = [tail_player]
 
-    detractors = (tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers)
-    mock_game.tackle_zones_in_detailed.return_value = detractors
+    tz_details = TackleZoneDetails(tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers)
+    mock_game.get_tackle_zones_detailed.return_value = tz_details
 
     pos = Square(11, 12)
     modifier = Dodge.dodge_modifiers(mock_game, player, pos)

--- a/tests/test_dodge.py
+++ b/tests/test_dodge.py
@@ -2,6 +2,7 @@ import pytest
 from ffai.core.game import *
 from unittest.mock import *
 
+
 @patch("ffai.core.game.Game")
 def test_default_dodge_modifier(mock_game):
     mock_game.num_tackle_zones_at.return_value = 0 # no tackle zones in target square
@@ -18,27 +19,27 @@ def test_default_dodge_modifier(mock_game):
 
 @patch("ffai.core.game.Game")
 def test_prehensile_tail_modifier(mock_game):
-    mock_game.num_tackle_zones_at.return_value = 0 # no tackle zones in target square
+    # no tackle zones in target square
+    mock_game.num_tackle_zones_at.return_value = 0
 
+    # set up dodging player
     role = Role("Lineman", "orc", 6,3,3,9, [], 50000, None)
     player = Player("1", role, "test", 1, "orc")
 
-    # set up a detractor in square moving from
-    tail_player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.PREHENSILE_TAIL])
-    
-    pos = Square(11,12)
-    prehensile_tailers = [tail_player]
+    # set up a detractors in square moving from
     tackle_zones = 0
-
     tacklers = []
-    # prehensile_tailers = []
     diving_tacklers = []
     shadowers = []
     tentaclers = []
 
-    detractors = (tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers)
+    tail_player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.PREHENSILE_TAIL])
+    prehensile_tailers = [tail_player]
 
-    # need to test static method to ensure calculation for lookahead requests
-    modifier = Dodge.dodge_modifiers(mock_game, player, pos, detractors=detractors)
+    detractors = (tackle_zones, tacklers, prehensile_tailers, diving_tacklers, shadowers, tentaclers)
+    mock_game.tackle_zones_in_detailed.return_value = detractors
+
+    pos = Square(11, 12)
+    modifier = Dodge.dodge_modifiers(mock_game, player, pos)
 
     assert modifier == 0


### PR DESCRIPTION
turns out the hard work was done already, so just a case of wiring it through to the modifier calc.
Fixes issue #61 

There's a 6-part tuple returned by game.tackle_zones_in_detailed - could probably do with replacing with an explicit class.  It ran off down a rabbit hole into Pitch though, so I wasn't confident to refactor with abandon.
