### PR TITLE
preventing multiple use of dodge skill in one turn

### DIFF
--- a/ffai/core/model.py
+++ b/ffai/core/model.py
@@ -149,6 +149,7 @@ class PlayerState:
         self.ejected = False
         self.casualty_effect = None
         self.casualty_type = None
+        self.used_skills = []
 
     def to_json(self):
         return {
@@ -175,6 +176,12 @@ class PlayerState:
         self.hypnotized = False
         self.really_stupid = False
         self.heated = False
+        self.used_skills.clear()
+
+    def reset_turn(self):
+        self.moves = 0
+        self.used = False
+        self.used_skills.clear()
 
 
 class Agent:
@@ -781,6 +788,9 @@ class Player(Piece):
 
     def has_skill(self, skill):
         return skill in self.get_skills()
+
+    def has_used_skill(self, skill):
+        return skill in self.state.used_skills
 
     def get_skills(self):
         return self.role.skills + self.extra_skills

--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -1517,9 +1517,10 @@ class Dodge(Procedure):
                 self.game.report(Outcome(OutcomeType.FAILED_DODGE, player=self.player, position=self.position, rolls=[roll]))
 
                 # Check if dodge
-                if self.player.has_skill(Skill.DODGE) and not self.dodge_used and len(tacklers) == 0:
+                if self.player.has_skill(Skill.DODGE) and not self.player.has_used_skill(Skill.DODGE) and not self.dodge_used and len(tacklers) == 0:
                     self.dodge_used = True
                     self.awaiting_dodge = True
+                    self.player.state.used_skills.append(Skill.DODGE)
                     self.game.report(Outcome(OutcomeType.SKILL_USED, player=self.player, skill=Skill.DODGE))
                     return False
 
@@ -2717,9 +2718,8 @@ class EndTurn(Procedure):
         if self.game.state.current_team is not None:
             self.game.state.current_team.state.reset_turn()
             for player in self.game.state.current_team.players:
-                player.state.moves = 0
-                if player.state.used:
-                    player.state.used = False
+                player.state.reset_turn()
+
 
         # Add kickoff procedure - if there are more turns left
         if self.kickoff and self.game.get_opp_team(self.game.state.current_team).state.turn < self.game.config.rounds:


### PR DESCRIPTION
Added a list within the PlayerState that tracks used_skills within the turn (cleared during EndTurn)

fixes issue #66 