### PR TITLE
Hiding the stack

### DIFF
--- a/ffai/ai/bots/grodbot.py
+++ b/ffai/ai/bots/grodbot.py
@@ -104,6 +104,8 @@ class GrodBot(Agent):
             return self.dodge(game)
         if isinstance(proc, Pickup):
             return self.pickup(game)
+        if isinstance(proc, Negatrait):
+            return self.negatrait(game)
 
         raise Exception("Unknown procedure")
 
@@ -408,9 +410,10 @@ class GrodBot(Agent):
         """
         # Loop through available dice results
         active_player: Player = game.state.active_player
-        attacker: Player = game.state.stack.items[-1].attacker
-        defender: Player = game.state.stack.items[-1].defender
-        favor: Team = game.state.stack.items[-1].favor
+        block_context = game.get_procedure_context()
+        attacker: Player = block_context.attacker
+        defender: Player = block_context.defender
+        favor: Team = block_context.favor
 
         actions: List[ActionSequence] = []
         check_reroll = False
@@ -532,6 +535,13 @@ class GrodBot(Agent):
             print("I ({}) won".format(self.name))
         else:
             print("I ({}) lost".format(self.name))
+
+    def negatrait(self, game):
+        """
+        Reroll or not.
+        """
+        # return Action(ActionType.USE_REROLL)
+        return Action(ActionType.DONT_USE_REROLL)
 
 
 def block_favourability(block_result: ActionType, team: Team, active_player: Player, attacker: Player, defender: Player, favor: Team) -> float:

--- a/ffai/ai/bots/grodbot.py
+++ b/ffai/ai/bots/grodbot.py
@@ -61,7 +61,7 @@ class GrodBot(Agent):
         self.actions_available.append(available)
 
         # Get current procedure
-        proc = game.state.stack.peek()
+        proc = game.get_procedure_context()
 
         # Call private function
         if isinstance(proc, CoinTossFlip):
@@ -134,8 +134,8 @@ class GrodBot(Agent):
         Move players from the reserves to the pitch
         """
 
-        if isinstance(game.state.stack.peek(), Setup):
-            proc: Setup = game.state.stack.peek()
+        if isinstance(game.get_procedure_context(), Setup):
+            proc: Setup = game.get_procedure_context()
         else:
             raise ValueError('Setup procedure expected')
 

--- a/ffai/ai/bots/proc_bot.py
+++ b/ffai/ai/bots/proc_bot.py
@@ -17,7 +17,7 @@ class ProcBot(Agent):
     def act(self, game):
 
         # Get current procedure
-        proc = game.state.stack.peek()
+        proc = game.get_procedure_context()
 
         # Call private function
         if isinstance(proc, CoinTossFlip):

--- a/ffai/ai/env.py
+++ b/ffai/ai/env.py
@@ -345,7 +345,7 @@ class FFAIEnv(gym.Env):
 
         # Procedure
         if game.state.stack.size() > 0:
-            procedure = game.state.stack.peek()
+            procedure = game.get_procedure_context()
             assert procedure.__class__ in FFAIEnv.procedures
             proc_idx = FFAIEnv.procedures.index(procedure.__class__)
             obs['procedure'][proc_idx] = 1.0
@@ -376,7 +376,7 @@ class FFAIEnv(gym.Env):
         return self._observation(self.game)
 
     def available_action_types(self):
-        if isinstance(self.game.state.stack.peek(), Setup):
+        if isinstance(self.game.get_procedure_context(), Setup):
             if self.game.get_kicking_team().team_id == self.team_id:
                 return [self.actions.index(action_type) for action_type in self.defensive_formation_action_types]
             else:

--- a/ffai/core/game.py
+++ b/ffai/core/game.py
@@ -1812,3 +1812,12 @@ class Game:
             self.pitch_to_reserves(player)
         for player in self.get_players_on_pitch(self.state.away_team):
             self.pitch_to_reserves(player)
+
+    def get_procedure_context(self):
+        proc = None
+        for i in reversed(range(self.state.stack.size())):
+            proc = self.state.stack.items[i]
+            if proc.has_context:
+                return proc
+
+        return proc

--- a/ffai/core/model.py
+++ b/ffai/core/model.py
@@ -657,6 +657,10 @@ class BBDie(Die):
         else:
             raise ValueError("Fixed result of BBDie must be a BBDieResult")
 
+    @staticmethod
+    def clear_fixes():
+        BBDie.FixedRolls.clear()
+
     def __init__(self, rnd):
         if len(BBDie.FixedRolls) > 0:
             self.value = BBDie.FixedRolls.pop(0)

--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -21,6 +21,7 @@ class Procedure:
         self.game.state.stack.push(self)
         self.done = False
         self.initialized = False
+        self.has_context = True
 
     def setup(self):
         """
@@ -3046,6 +3047,8 @@ class WildAnimal(Negatrait):
 class ReRoll(Procedure):
     def __init__(self, game, player):
         super().__init__(game)
+        self.has_context = False
+
         self.player = player
         self.awaiting_input = False
         self.result = False  # not a success by default

--- a/ffai/core/table.py
+++ b/ffai/core/table.py
@@ -58,6 +58,7 @@ class RollType(Enum):
     BONE_HEAD_ROLL = 24
     REALLY_STUPID_ROLL = 25
     WILD_ANIMAL_ROLL = 26
+    LONER_ROLL = 27
 
 
 class OutcomeType(Enum):
@@ -194,6 +195,8 @@ class OutcomeType(Enum):
     SUCCESSFUL_REALLY_STUPID = 140
     FAILED_WILD_ANIMAL = 141
     SUCCESSFUL_WILD_ANIMAL = 142
+    SUCCESSFUL_LONER = 143
+    FAILED_LONER = 144
 
 
 class PlayerActionType(Enum):

--- a/ffai/web/static/dist/js/pybowl.js
+++ b/ffai/web/static/dist/js/pybowl.js
@@ -1609,7 +1609,9 @@ appServices.factory('GameLogService', function() {
             "FAILED_REALLY_STUPID": "<player> failed a <b>really stupid</b> roll",
             "SUCCESSFUL_REALLY_STUPID": "<player> passed a <b>really stupid</b> roll",
             "FAILED_WILD_ANIMAL": "<player> failed a <b>wild animal</b> roll",
-            "SUCCESSFUL_WILD_ANIMAL": "<player> passed a <b>wild animal</b> roll"
+            "SUCCESSFUL_WILD_ANIMAL": "<player> passed a <b>wild animal</b> roll",
+            "FAILED_LONER": "<player> failed a <b>loner</b> roll",
+            "SUCCESSFUL_LONER": "<player> passed a <b>loner</b> roll"
         }
     };
 });

--- a/ffai/web/static/js/services.js
+++ b/ffai/web/static/js/services.js
@@ -216,7 +216,10 @@ appServices.factory('GameLogService', function() {
             "FAILED_REALLY_STUPID": "<player> failed a <b>really stupid</b> roll",
             "SUCCESSFUL_REALLY_STUPID": "<player> passed a <b>really stupid</b> roll",
             "FAILED_WILD_ANIMAL": "<player> failed a <b>wild animal</b> roll",
-            "SUCCESSFUL_WILD_ANIMAL": "<player> passed a <b>wild animal</b> roll"
+            "SUCCESSFUL_WILD_ANIMAL": "<player> passed a <b>wild animal</b> roll",
+            "FAILED_LONER": "<player> failed a <b>loner</b> roll",
+            "SUCCESSFUL_LONER": "<player> passed a <b>loner</b> roll"
+
         }
     };
 });

--- a/tests/game/test_block.py
+++ b/tests/game/test_block.py
@@ -1,0 +1,187 @@
+from tests.util import *
+
+
+def test_block_uphill():
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0
+
+    attacker, defender = get_block_players(game, team)
+    attacker.extra_st = 0 - attacker.get_st() - 1 # set up uphill block
+    defender_pos = Square(defender.position.x, defender.position.y)
+    # it's a 2 dice block
+    BBDie.clear_fixes()
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    game.step(Action(ActionType.START_BLOCK, player=attacker))
+    game.step(Action(ActionType.BLOCK, position=defender.position))
+    actions = game.get_available_actions()
+    assert len(actions) == 3  # 3 die block uphill, no reroll
+    game.step(Action(ActionType.SELECT_ATTACKER_DOWN))
+    assert not attacker.state.up
+
+
+def test_block_uphill_reroll_refused():
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 1
+
+    attacker, defender = get_block_players(game, team)
+    attacker.extra_st = 0 - attacker.get_st() - 1 # set up uphill block
+    defender_pos = Square(defender.position.x, defender.position.y)
+    # it's a 2 dice block
+    BBDie.clear_fixes()
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    game.step(Action(ActionType.START_BLOCK, player=attacker))
+    game.step(Action(ActionType.BLOCK, position=defender.position))
+    actions = game.get_available_actions()
+    assert len(actions) == 5  # 3 die block uphill, with reroll
+    # dice action choices are disabled - it's a reroll choice
+    assert not actions[0].disabled
+    assert not actions[1].disabled
+    assert actions[2].disabled
+    assert actions[3].disabled
+    assert actions[4].disabled
+
+    game.step(Action(ActionType.DONT_USE_REROLL))
+    actions = game.get_available_actions()
+    assert len(actions) == 3  # 3 die block uphill, no reroll choices
+    # dice action choices are no longer disabled
+    assert not actions[0].disabled
+    assert not actions[1].disabled
+    assert not actions[2].disabled
+
+    game.step(Action(ActionType.SELECT_ATTACKER_DOWN))
+    assert not attacker.state.up
+
+def test_block_uphill_reroll_used():
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 1
+
+    attacker, defender = get_block_players(game, team)
+    attacker.extra_st = 0 - attacker.get_st() - 1 # set up uphill block
+    defender_pos = Square(defender.position.x, defender.position.y)
+    # it's a 2 dice block
+    BBDie.clear_fixes()
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.DEFENDER_DOWN)
+    BBDie.fix_result(BBDieResult.BOTH_DOWN)
+    BBDie.fix_result(BBDieResult.BOTH_DOWN)
+    game.step(Action(ActionType.START_BLOCK, player=attacker))
+    game.step(Action(ActionType.BLOCK, position=defender.position))
+    actions = game.get_available_actions()
+    assert len(actions) == 5  # 3 die block uphill, with reroll
+    # dice action choices are disabled - it's a reroll choice
+    assert not actions[0].disabled
+    assert not actions[1].disabled
+    assert actions[2].disabled
+    assert actions[3].disabled
+    assert actions[4].disabled
+
+    game.step(Action(ActionType.USE_REROLL))
+    actions = game.get_available_actions()
+    assert len(actions) == 3  # 3 die block uphill, no reroll choices
+    # dice action choices are no longer disabled
+    assert not actions[0].disabled
+    assert not actions[1].disabled
+    assert not actions[2].disabled
+
+    game.step(Action(ActionType.SELECT_BOTH_DOWN))
+    assert attacker.state.up == attacker.has_skill(Skill.BLOCK)
+    assert defender.state.up == defender.has_skill(Skill.BLOCK)
+
+def test_block():
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0
+
+    attacker, defender = get_block_players(game, team)
+    attacker.extra_st = defender.get_st() - attacker.get_st() + 1  # make this a 2 die block.
+    defender_pos = Square(defender.position.x, defender.position.y)
+    # it's a 2 dice block
+    BBDie.clear_fixes()
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+
+    game.step(Action(ActionType.START_BLOCK, player=attacker))
+    game.step(Action(ActionType.BLOCK, position=defender.position))
+    game.step(Action(ActionType.SELECT_ATTACKER_DOWN))
+    assert not attacker.state.up
+
+
+def test_block_reroll():
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 1
+
+    attacker, defender = get_block_players(game, team)
+    attacker.extra_st = defender.get_st() - attacker.get_st() + 1  # make this a 2 die block.
+    # it's a 2 dice block
+    BBDie.clear_fixes()
+    BBDie.fix_result(BBDieResult.DEFENDER_DOWN)
+    BBDie.fix_result(BBDieResult.DEFENDER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    game.step(Action(ActionType.START_BLOCK, player=attacker))
+    game.step(Action(ActionType.BLOCK, position=defender.position))
+    game.step(Action(ActionType.USE_REROLL))
+    game.step(Action(ActionType.SELECT_ATTACKER_DOWN))
+    assert not attacker.state.up
+
+
+def test_block_ignore_reroll():
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 1
+
+    attacker, defender = get_block_players(game, team)
+    attacker.extra_st = defender.get_st() - attacker.get_st() + 1  # make this a 2 die block.
+    #defender.extra_skills.append(Skill.STAND_FIRM)
+    # it's a 2 dice block
+    BBDie.clear_fixes()
+    BBDie.fix_result(BBDieResult.DEFENDER_DOWN)
+    BBDie.fix_result(BBDieResult.DEFENDER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    game.step(Action(ActionType.START_BLOCK, player=attacker))
+    game.step(Action(ActionType.BLOCK, position=defender.position))
+    game.step(Action(ActionType.SELECT_DEFENDER_DOWN))
+    game.step(Action(ActionType.PUSH, position=game.get_available_actions()[0].positions[0]))
+    game.step(Action(ActionType.FOLLOW_UP, position=game.get_available_actions()[0].positions[0]))
+    assert attacker.state.up
+    assert not defender.state.up
+
+
+def test_available_actions_on_block_reroll():
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 1
+
+    attacker, defender = get_block_players(game, team)
+    attacker.extra_st = defender.get_st() - attacker.get_st() + 1  # make this a 2 die block.
+    # it's a 2 dice block
+    BBDie.clear_fixes()
+    BBDie.fix_result(BBDieResult.DEFENDER_DOWN)
+    BBDie.fix_result(BBDieResult.DEFENDER_STUMBLES)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    BBDie.fix_result(BBDieResult.ATTACKER_DOWN)
+    game.step(Action(ActionType.START_BLOCK, player=attacker))
+    game.step(Action(ActionType.BLOCK, position=defender.position))
+    actions = game.get_available_actions()
+    assert actions[0].action_type == ActionType.USE_REROLL
+    assert actions[1].action_type == ActionType.DONT_USE_REROLL
+    assert actions[2].action_type == ActionType.SELECT_DEFENDER_DOWN
+    assert actions[3].action_type == ActionType.SELECT_DEFENDER_STUMBLES
+
+    game.step(Action(ActionType.DONT_USE_REROLL))
+    actions = game.get_available_actions()
+    assert actions[0].action_type == ActionType.SELECT_DEFENDER_DOWN
+    assert actions[1].action_type == ActionType.SELECT_DEFENDER_STUMBLES
+
+

--- a/tests/game/test_dice.py
+++ b/tests/game/test_dice.py
@@ -87,6 +87,7 @@ def test_d8_fixation():
 
 
 def test_bb_fixation():
+    BBDie.clear_fixes()
     for seed in range(10):
         rnd = np.random.RandomState(seed)
         BBDie.fix_result(BBDieResult.ATTACKER_DOWN)

--- a/tests/game/test_negatraits.py
+++ b/tests/game/test_negatraits.py
@@ -1,293 +1,217 @@
 import pytest
-from ffai.core.game import *
-from unittest.mock import *
-import numpy as np
+from tests.util import *
 
 
 @pytest.mark.parametrize("trait", [[Skill.BONE_HEAD, Bonehead], [Skill.REALLY_STUPID, ReallyStupid], [Skill.WILD_ANIMAL, WildAnimal]])
-@patch("ffai.core.game.Game")
-def test_negatrait_pass_allows_player_action(mock_game, trait):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
+def test_negatrait_pass_allows_player_action(trait):
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
 
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
+    players = game.get_players_on_pitch(team)
+    player = players[1]
+    player.extra_skills = [trait[0]]
 
-        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
-        player = Player("1", role, "test", 1, "orc", extra_skills=[trait[0]])
+    D6.FixedRolls.clear()
+    D6.fix_result(6)  # pass trait test
 
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(ActionType.START_MOVE, player=player)
-        turn.step(action)
-        proc = stack.peek()
+    game.step(Action(ActionType.START_MOVE, player=player))
 
-        assert isinstance(proc, trait[1])
+    # check the player turn has not ended
+    assert game.state.active_player is player
 
-        D6.FixedRolls.clear()
-        D6.fix_result(4)  # fix a pass
-        result = proc.step(None)
-        assert result is True  # trait is done
-        # get rid of trait
-        stack.pop()
-        proc = stack.peek()
-        assert isinstance(proc, PlayerAction)
-        assert proc.done is False
+    # check the player state
+    if trait[0] is Skill.BONE_HEAD:
+        assert not player.state.bone_headed
+    elif trait[0] is Skill.REALLY_STUPID:
+        assert not player.state.really_stupid
+
+    # check the player can continue move
+    to = Square(player.position.x, player.position.y + 1)
+    game.step(Action(ActionType.MOVE, player=player, position=to))
+    assert player.position == to
 
 
 @pytest.mark.parametrize("trait", [[Skill.BONE_HEAD, Bonehead], [Skill.REALLY_STUPID, ReallyStupid], [Skill.WILD_ANIMAL, WildAnimal]])
-@patch("ffai.core.game.Game")
-def test_negatrait_fail_ends_turn(mock_game, trait):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
+def test_negatrait_fail_ends_turn(trait):
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
 
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
+    players = game.get_players_on_pitch(team)
+    player = players[1]
+    player.extra_skills = [trait[0]]
 
-        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
-        player = Player("1", role, "test", 1, "orc", extra_skills=[trait[0]])
+    D6.FixedRolls.clear()
+    D6.fix_result(1)  # fail trait test
 
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(ActionType.START_MOVE, player=player)
-        turn.step(action)
-        proc = stack.peek()
-        assert isinstance(proc, trait[1])
+    game.step(Action(ActionType.START_MOVE, player=player))
 
-        D6.FixedRolls.clear()
-        D6.fix_result(1)
-        result = proc.step(None)
-        assert result is True # bonehead is done without reroll
-        # get rid of bonehead
-        proc = stack.peek()
-        assert isinstance(proc, EndPlayerTurn)
-        assert proc.done is False
-        # check state
-        if trait[0] is Skill.BONE_HEAD:
-            assert player.state.bone_headed
-        elif trait[0] is Skill.REALLY_STUPID:
-            assert player.state.really_stupid
+    # check the player turn has ended
+    assert game.state.active_player is not player
+
+    # check the player state
+    if trait[0] is Skill.BONE_HEAD:
+        assert player.state.bone_headed
+    elif trait[0] is Skill.REALLY_STUPID:
+        assert player.state.really_stupid
+
 
 # no wild animal test as wild animal has no state impact
 @pytest.mark.parametrize("trait", [[Skill.BONE_HEAD, Bonehead], [Skill.REALLY_STUPID, ReallyStupid]])
-@patch("ffai.core.game.Game")
-def test_negatrait_success_resets_player_state(mock_game, trait):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
+def test_negatrait_success_resets_player_state(trait):
+        game = get_game_turn()
+        team = game.get_agent_team(game.actor)
+        team.state.rerolls = 0  # ensure no reroll prompt
 
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
-
-        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
-        # create boneheaded player
-        player = Player("1", role, "test", 1, "orc", extra_skills=[trait[0]])
+        players = game.get_players_on_pitch(team)
+        player = players[1]
+        player.extra_skills = [trait[0]]
 
         if trait[0] is Skill.BONE_HEAD:
             player.state.bone_headed = True
         elif trait[0] is Skill.REALLY_STUPID:
             player.state.really_stupid = True
 
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(ActionType.START_MOVE, player=player)
-        turn.step(action)
-        proc = stack.peek()
-        assert isinstance(proc, trait[1])
-
         D6.FixedRolls.clear()
-        D6.fix_result(4)
-        result = proc.step(None)
-        assert result is True  # negatrait is done without reroll
+        D6.fix_result(6)  # pass trait test
 
-        # check state
+        game.step(Action(ActionType.START_MOVE, player=player))
+
+        # check the player turn has not ended
+        assert game.state.active_player is player
+
+        # check the player state
         if trait[0] is Skill.BONE_HEAD:
             assert not player.state.bone_headed
         elif trait[0] is Skill.REALLY_STUPID:
             assert not player.state.really_stupid
 
+
 @pytest.mark.parametrize("dice_value", [1,2,3])
-@patch("ffai.core.game.Game")
-def test_really_stupid_fails_without_support(mock_game, dice_value):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
+def test_really_stupid_fails_without_support(dice_value):
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
 
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
+    players = game.get_players_on_pitch(team)
+    player = players[1]
+    player.extra_skills = [Skill.REALLY_STUPID]
 
-        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
-        player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.REALLY_STUPID])
+    game.put(player, Square(5, 5))
+    adjacent = game.get_adjacent_teammates(player)
+    assert len(adjacent) == 0
 
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(ActionType.START_MOVE, player=player)
-        turn.step(action)
-        proc = stack.peek()
-        assert isinstance(proc, ReallyStupid)
+    D6.FixedRolls.clear()
+    D6.fix_result(dice_value)  # fail trait test
 
-        D6.FixedRolls.clear()
-        D6.fix_result(dice_value)
-        result = proc.step(None)
-        assert result is True  # trait is done without reroll
+    game.step(Action(ActionType.START_MOVE, player=player))
 
-        proc = stack.peek()
-        assert isinstance(proc, EndPlayerTurn)
-        assert proc.done is False
-        # check state
-        assert player.state.really_stupid
+    # check the player turn has ended
+    assert game.state.active_player is not player
 
-@pytest.mark.parametrize("dice_value", [2,3])
-@patch("ffai.core.game.Game")
-def test_really_stupid_passes_with_support(mock_game, dice_value):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
-    role = Role("Blitzer", "orc", 6, 3, 3, 9, [], 50000, None)
-    team_mate = Player("3", role, "test", 1, "orc")
-
-    mock_game.get_adjacent_teammates.return_value = [team_mate]
-
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
-
-        player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.REALLY_STUPID])
-
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(ActionType.START_MOVE, player=player)
-        turn.step(action)
-        proc = stack.peek()
-        assert isinstance(proc, ReallyStupid)
-
-        D6.FixedRolls.clear()
-        D6.fix_result(dice_value)
-        result = proc.step(None)
-        assert result is True  # negatrait is done without reroll
-
-        # check state
-        assert not player.state.really_stupid
+    # check the player state
+    assert player.state.really_stupid
 
 
 @pytest.mark.parametrize("dice_value", [2,3])
-@patch("ffai.core.game.Game")
-def test_really_stupid_fails_if_support_is_really_stupid(mock_game, dice_value):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
-    role = Role("Blitzer", "orc", 6, 3, 3, 9, [], 50000, None)
-    team_mate = Player("3", role, "test", 1, "orc", extra_skills=[Skill.REALLY_STUPID])
+def test_really_stupid_passes_with_support(dice_value):
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
 
-    mock_game.get_adjacent_teammates.return_value = [team_mate]
+    players = game.get_players_on_pitch(team)
+    player = players[1]
+    player.extra_skills = [Skill.REALLY_STUPID]
 
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
+    team_mate = players[2]
+    assert not team_mate.has_skill(Skill.REALLY_STUPID)
+    game.put(player, Square(5, 5))
+    game.put(team_mate, Square(5,6))
 
-        player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.REALLY_STUPID])
+    adjacent = game.get_adjacent_teammates(player)
+    assert len(adjacent) == 1
 
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(ActionType.START_MOVE, player=player)
-        turn.step(action)
-        proc = stack.peek()
-        assert isinstance(proc, ReallyStupid)
+    D6.FixedRolls.clear()
+    D6.fix_result(dice_value)  # pass trait test if supported
 
-        D6.FixedRolls.clear()
-        D6.fix_result(dice_value)
-        result = proc.step(None)
-        assert result is True  # trait is done without reroll
+    game.step(Action(ActionType.START_MOVE, player=player))
 
-        proc = stack.peek()
-        assert isinstance(proc, EndPlayerTurn)
-        assert proc.done is False
-        # check state
-        assert player.state.really_stupid
+    # check the player turn has ended
+    assert game.state.active_player is player
+
+    # check the player state
+    assert not player.state.really_stupid
+
+
+@pytest.mark.parametrize("dice_value", [2,3])
+def test_really_stupid_fails_if_support_is_really_stupid(dice_value):
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
+
+    players = game.get_players_on_pitch(team)
+    player = players[1]
+    player.extra_skills = [Skill.REALLY_STUPID]
+
+    team_mate = players[2]
+    team_mate.extra_skills.append(Skill.REALLY_STUPID)
+    game.put(player, Square(5, 5))
+    game.put(team_mate, Square(5,6))
+
+    adjacent = game.get_adjacent_teammates(player)
+    assert len(adjacent) == 1
+
+    D6.FixedRolls.clear()
+    D6.fix_result(dice_value)  # fail trait test if supported by really stupid player
+
+    game.step(Action(ActionType.START_MOVE, player=player))
+
+    # check the player turn has ended
+    assert game.state.active_player is not player
+
+    # check the player state
+    assert player.state.really_stupid        # check state
 
 
 @pytest.mark.parametrize("action_type", [ActionType.START_MOVE, ActionType.START_FOUL, ActionType.START_HANDOFF, ActionType.START_PASS])
-@patch("ffai.core.game.Game")
-def test_wild_animal_fails_without_block_or_blitz(mock_game, action_type):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
+def test_wild_animal_fails_without_block_or_blitz(action_type):
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
 
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
+    players = game.get_players_on_pitch(team)
+    player = players[1]
+    player.extra_skills = [Skill.WILD_ANIMAL]
 
-        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
-        player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.WILD_ANIMAL])
+    D6.FixedRolls.clear()
+    D6.fix_result(2)  # fails without block/blitz
 
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(action_type, player=player)
-        turn.step(action)
-        proc = stack.peek()
-        assert isinstance(proc, WildAnimal)
+    game.step(Action(action_type, player=player))
 
-        D6.FixedRolls.clear()
-        D6.fix_result(2)  # Fails without a block/blitz
-        result = proc.step(None)
-        assert result is True  # trait is done without reroll
-
-        proc = stack.peek()
-        assert isinstance(proc, EndPlayerTurn)
-        assert proc.done is False
-        # check state
-        assert player.state.wild_animal
+    # check the player turn has ended
+    assert game.state.active_player is not player
+    assert game.has_report_of_type(OutcomeType.FAILED_WILD_ANIMAL)
 
 
+@pytest.mark.parametrize("action_type", [ActionType.START_BLITZ, ActionType.START_BLOCK])
+def test_wild_animal_passes_when_block_or_blitz(action_type):
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
 
-@pytest.mark.parametrize("action_type", [ActionType.START_BLITZ, ActionType.START_BLOCK] )
-@patch("ffai.core.game.Game")
-def test_wild_animal_passes_when_block_or_blitz(mock_game, action_type):
-    # patch the mock game proc stack
-    stack = Stack()
-    mock_game.state.stack = stack
-    mock_game.can_use_reroll.return_value = False
+    attacker, defender = get_block_players(game, team)  # need adjacent players here.
 
-    with patch("ffai.core.util.Stack", new_callable=PropertyMock) as a:
-        a.return_value = stack
+    attacker.extra_skills = [Skill.WILD_ANIMAL]
 
-        role = Role("Blitzer", "orc", 6,3,3,9, [], 50000, None)
-        player = Player("1", role, "test", 1, "orc", extra_skills=[Skill.WILD_ANIMAL])
+    D6.FixedRolls.clear()
+    D6.fix_result(2)  # fails without block/blitz
 
-        team = Team("humans", "dudes", Race("orc", None, 10, False, None))
-        # test subject
-        turn = Turn(mock_game, team, None, None)
-        turn.started = True
-        action = Action(action_type, player=player)
-        turn.step(action)
-        proc = stack.peek()
-        assert isinstance(proc, WildAnimal)
+    game.step(Action(action_type, player=attacker))
 
-        D6.FixedRolls.clear()
-        D6.fix_result(2)  # fails without block/blitz
-        result = proc.step(None)
-        assert result is True  # negatrait is done without reroll
+    # check the player turn has ended
+    assert not game.has_report_of_type(OutcomeType.FAILED_WILD_ANIMAL)
+    assert game.has_report_of_type(OutcomeType.SUCCESSFUL_WILD_ANIMAL)
 
-        # check state
-        assert not player.state.wild_animal
+
 

--- a/tests/game/test_reroll.py
+++ b/tests/game/test_reroll.py
@@ -43,6 +43,13 @@ def test_bonehead_reroll_success():
     D6.fix_result(1)  # fail first bonehead
     D6.fix_result(4)  # pass on re-roll
     game.step(Action(ActionType.START_MOVE, player=player))  # should bonehead and present reroll choice
+
+    # check that in a reroll context the game domain context is still Bonehead
+    proc = game.get_procedure_context()
+    assert isinstance(proc, Bonehead)
+    # but that the top of the stack is a reroll proc
+    assert isinstance(game.state.stack.peek(), ReRoll)
+
     game.step(Action(ActionType.USE_REROLL))  # use reroll
 
     assert not player.state.bone_headed

--- a/tests/game/test_reroll.py
+++ b/tests/game/test_reroll.py
@@ -1,0 +1,150 @@
+from tests.util import *
+
+
+def test_dodge_reroll_success():
+    game = get_game_turn()
+    current_team = game.get_agent_team(game.actor)
+
+    players = game.get_players_on_pitch(team=current_team)
+    player = players[1]
+    # allow a team reroll
+    game.state.teams[0].state.rerolls = 1
+
+    opponents = game.get_players_on_pitch(game.get_opp_team(current_team))
+    game.put(player, Square(11, 11))
+
+    opp_player = opponents[1]
+    game.put(opp_player, Square(12, 12))
+    game.step(Action(ActionType.START_MOVE, player=player))
+    to = Square(11, 12)
+    assert game.get_player_at(to) is None
+    D6.fix_result(1)  # fail first dodge
+    D6.fix_result(4)  # pass on re-roll
+
+    game.step(Action(ActionType.MOVE, player=player, position=to))
+    game.step(Action(ActionType.USE_REROLL))
+    assert player.position == to
+    assert player.state.up
+    assert game.has_report_of_type(OutcomeType.FAILED_DODGE)
+    assert game.has_report_of_type(OutcomeType.SUCCESSFUL_DODGE)
+
+
+def test_bonehead_reroll_success():
+    game = get_game_turn()
+    current_team = game.get_agent_team(game.actor)
+
+    players = game.get_players_on_pitch(team=current_team)
+    player = players[1]
+    player.extra_skills = [Skill.BONE_HEAD]
+
+    game.state.teams[0].state.rerolls = 1
+    game.put(player, Square(11, 11))
+
+    D6.fix_result(1)  # fail first bonehead
+    D6.fix_result(4)  # pass on re-roll
+    game.step(Action(ActionType.START_MOVE, player=player))  # should bonehead and present reroll choice
+    game.step(Action(ActionType.USE_REROLL))  # use reroll
+
+    assert not player.state.bone_headed
+    assert game.has_report_of_type(OutcomeType.FAILED_BONE_HEAD)
+    assert game.has_report_of_type(OutcomeType.SUCCESSFUL_BONE_HEAD)
+
+
+def test_gfi_reroll_success():
+    game = get_game_turn()
+    current_team = game.get_agent_team(game.actor)
+
+    players = game.get_players_on_pitch(team=current_team)
+    player = players[1]
+    player.extra_ma = - player.get_ma()
+
+    game.state.teams[0].state.rerolls = 1
+    game.put(player, Square(5, 5))
+
+    D6.fix_result(1)  # fail first gfi
+    D6.fix_result(4)  # pass on re-roll
+    game.step(Action(ActionType.START_MOVE, player=player))
+    to = Square(player.position.x + 1, player.position.y)
+    game.step(Action(ActionType.MOVE, player=player, position=to))
+    game.step(Action(ActionType.USE_REROLL))  # use reroll
+
+    assert player.state.up
+    assert game.has_report_of_type(OutcomeType.FAILED_GFI)
+    assert game.has_report_of_type(OutcomeType.REROLL_USED)
+    assert game.has_report_of_type(OutcomeType.SUCCESSFUL_GFI)
+
+
+def test_gfi_reroll_fail():
+    game = get_game_turn()
+    current_team = game.get_agent_team(game.actor)
+
+    players = game.get_players_on_pitch(team=current_team)
+    player = players[1]
+    player.extra_ma = - player.get_ma()
+
+    game.state.teams[0].state.rerolls = 1
+    game.put(player, Square(5, 5))
+
+    D6.fix_result(1)  # fail first gfi
+    D6.fix_result(1)  # FAIL re-roll
+    game.step(Action(ActionType.START_MOVE, player=player))
+    to = Square(player.position.x + 1, player.position.y)
+    game.step(Action(ActionType.MOVE, player=player, position=to))
+    game.step(Action(ActionType.USE_REROLL))  # use reroll
+
+    assert not player.state.up
+    assert game.has_report_of_type(OutcomeType.FAILED_GFI)
+    assert game.has_report_of_type(OutcomeType.REROLL_USED)
+    assert not game.has_report_of_type(OutcomeType.SUCCESSFUL_GFI)
+
+
+def test_bonehead_loner_reroll_success():
+    game = get_game_turn()
+    current_team = game.get_agent_team(game.actor)
+
+    players = game.get_players_on_pitch(team=current_team)
+    player = players[1]
+    player.extra_skills = [Skill.BONE_HEAD, Skill.LONER]
+
+    # make sure we don't get stuck waiting for re-roll actions
+    game.state.teams[0].state.rerolls = 1
+    game.put(player, Square(11, 11))
+
+    D6.fix_result(1)  # fail first bonehead
+    D6.fix_result(4)  # pass loner
+    D6.fix_result(4)  # pass on re-roll
+    game.step(Action(ActionType.START_MOVE, player=player))  # should bonehead and present reroll choice
+    game.step(Action(ActionType.USE_REROLL))  # use reroll
+
+    assert not player.state.bone_headed
+    assert game.has_report_of_type(OutcomeType.FAILED_BONE_HEAD)
+    assert game.has_report_of_type(OutcomeType.SUCCESSFUL_LONER)
+    assert game.has_report_of_type(OutcomeType.REROLL_USED)
+    assert game.has_report_of_type(OutcomeType.SUCCESSFUL_BONE_HEAD)
+
+
+def test_bonehead_loner_reroll_fail():
+    game = get_game_turn()
+    current_team = game.get_agent_team(game.actor)
+
+    players = game.get_players_on_pitch(team=current_team)
+    player = players[1]
+    player.extra_skills = [Skill.BONE_HEAD, Skill.LONER]
+
+    # make sure we don't get stuck waiting for re-roll actions
+    game.state.teams[0].state.rerolls = 1
+    game.put(player, Square(11, 11))
+
+    D6.fix_result(1)  # fail first bonehead
+    D6.fix_result(3)  # fail loner
+    D6.fix_result(6)  # pass on re-roll - shouldn't be used
+    game.step(Action(ActionType.START_MOVE, player=player))  # should bonehead and present reroll choice
+    game.step(Action(ActionType.USE_REROLL))  # use reroll - should fail loner test
+
+    assert player.state.bone_headed
+    assert game.has_report_of_type(OutcomeType.FAILED_BONE_HEAD)
+    assert game.has_report_of_type(OutcomeType.FAILED_LONER)
+    assert game.has_report_of_type(OutcomeType.REROLL_USED)  # reroll was wasted
+    assert not game.has_report_of_type(OutcomeType.SUCCESSFUL_BONE_HEAD)  # no bonehead success
+
+

--- a/tests/kickoff/test_kickoff_table.py
+++ b/tests/kickoff/test_kickoff_table.py
@@ -52,7 +52,7 @@ def test_perfect_defence():
     D6.fix_result(2)
     D6.fix_result(2)
     game.step(Action(ActionType.PLACE_BALL, position=game.state.available_actions[0].positions[0]))
-    proc = game.state.stack.peek()
+    proc = game.get_procedure_context()
     assert game.has_report_of_type(OutcomeType.KICKOFF_PERFECT_DEFENSE)
     assert type(proc) == Setup
     team = game.get_agent_team(game.actor)
@@ -93,7 +93,7 @@ def test_high_kick():
     ball_placed_at = get_empty_square_without_adjacent_players(game, y=6)
     assert ball_placed_at is not None
     game.step(Action(ActionType.PLACE_BALL, position=ball_placed_at))
-    proc = game.state.stack.peek()
+    proc = game.get_procedure_context()
     assert game.has_report_of_type(OutcomeType.KICKOFF_HIGH_KICK)
     assert type(proc) == HighKick
     team = game.get_receiving_team()
@@ -128,7 +128,7 @@ def test_high_kick_touchback():
     ball_placed_at = get_empty_square_without_adjacent_players(game, y=1)
     assert ball_placed_at is not None
     game.step(Action(ActionType.PLACE_BALL, position=ball_placed_at))
-    proc = game.state.stack.peek()
+    proc = game.get_procedure_context()
     assert game.has_report_of_type(OutcomeType.KICKOFF_HIGH_KICK)
     assert game.has_report_of_type(OutcomeType.TOUCHBACK)
     assert type(proc) == Touchback

--- a/tests/kickoff/test_setup.py
+++ b/tests/kickoff/test_setup.py
@@ -20,7 +20,7 @@ def clear_board(game):
 def test_scrimmage_setup(home_team):
     game = get_game_setup(home_team)
     team = game.state.home_team if home_team else game.state.away_team
-    proc = game.state.stack.peek()
+    proc = game.get_procedure_context()
     assert type(proc) == Setup
 
     # Empty board
@@ -65,7 +65,7 @@ def test_scrimmage_setup(home_team):
 def test_wings_setup(home_team):
     game = get_game_setup(home_team)
     team = game.state.home_team if home_team else game.state.away_team
-    proc = game.state.stack.peek()
+    proc = game.get_procedure_context()
     assert type(proc) == Setup
 
     # Top Wing
@@ -97,7 +97,7 @@ def test_wings_setup(home_team):
 def test_player_count_setup(home_team):
     game = get_game_setup(home_team)
     team = game.state.home_team if home_team else game.state.away_team
-    proc = game.state.stack.peek()
+    proc = game.get_procedure_context()
     assert type(proc) == Setup
     assert not game.is_setup_legal_count(team)
     # Max players

--- a/tests/pregame/test_coin_toss.py
+++ b/tests/pregame/test_coin_toss.py
@@ -11,13 +11,13 @@ def test_coin_toss(action_type):
             return
         game = get_game_coin_toss()
         game.step(Action(ActionType.START_GAME))
-        proc = game.state.stack.peek()
+        proc = game.get_procedure_context()
         assert type(proc) is CoinTossFlip
         actor_id = game.actor.agent_id
         acting_team = game.get_agent_team(game.actor)
         game.set_seed(i)
         game.step(Action(action_type))
-        proc = game.state.stack.peek()
+        proc = game.get_procedure_context()
         assert type(proc) is CoinTossKickReceive
         if action_type == ActionType.HEADS:
             if game.has_report_of_type(OutcomeType.HEADS_WON):
@@ -56,13 +56,13 @@ def test_kick_receive(action_type):
         game.set_seed(i)
         game.step(Action(ActionType.START_GAME))
         game.step(Action(ActionType.HEADS))
-        proc = game.state.stack.peek()
+        proc = game.get_procedure_context()
         assert type(proc) is CoinTossKickReceive
         selector = game.actor
         selecting_team = game.get_agent_team(game.actor)
         actors.add(game.home_agent == selector)
         game.step(Action(action_type))
-        proc = game.state.stack.peek()
+        proc = game.get_procedure_context()
         assert type(proc) is Setup
         if action_type == ActionType.KICK:
             assert game.has_report_of_type(

--- a/tests/util.py
+++ b/tests/util.py
@@ -21,7 +21,7 @@ def get_game_turn(seed=0, empty=False):
     game.step(Action(ActionType.SETUP_FORMATION_WEDGE))
     game.step(Action(ActionType.END_SETUP))
     random_agent = RandomBot("home")
-    while type(game.state.stack.peek()) is not Turn and not game.is_quick_snap() and not game.is_blitz():
+    while type(game.get_procedure_context()) is not Turn and not game.is_quick_snap() and not game.is_blitz():
         action = random_agent.act(game)
         game.step(action)
     if empty:

--- a/tests/util.py
+++ b/tests/util.py
@@ -111,3 +111,19 @@ def get_game_weather_table(seed=0):
     game.set_seed(seed)
     #game.init()
     return game
+
+
+def get_block_players(game, team):
+    # get a player
+    players = game.get_players_on_pitch(team, False, True)
+    attacker = None
+    defender = None
+    for p in players:
+        if p.team != team:
+            continue
+        attacker = p
+        adjacent = game.get_adjacent_opponents(attacker)
+        if len(adjacent) > 0:
+            defender = adjacent[0]
+            break
+    return attacker, defender


### PR DESCRIPTION
This is the basic approach mentioned in issue #85 

I have replaced all calls to game.state.stack.peek() with a new method 'game.get_procedure_context()'. This returns the latest Procedure that dictates the game's context e.g. Dodge, Block etc... but ultimately should be changed to abstract away from the Procedure class details.

The Procedure class now has a field 'has_context' which is true by default, but for the new ReRoll procedure the value is set to False. This means that the ReRoll procedure is not dictating the game context, and should not be returned when get_procedure_context is called.

get_procedure_context simply walks down the stack looking for the first procedure where has_context is true.

new procedures: reroll and loner to demo how these would work as procedures - currently only triggered from the negatraits. 

