### PR TITLE
Bugfix - apothecary condition and safe throw implementation 

### DIFF
--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -2085,6 +2085,7 @@ class PassAction(Procedure):
         self.dump_off = dump_off
         self.catcher = None
         self.eat_thrall = None 
+        self.safe_throw_used = False 
 
     def start(self):
         if self.dump_off:
@@ -2142,7 +2143,8 @@ class PassAction(Procedure):
             elif mod_result <= 1 and self.passer.has_skill(Skill.SAFE_THROW):
                 # Inaccurate pass - Safe Throw
                 self.game.report(Outcome(OutcomeType.SKILL_USED, player=self.passer, skill=Skill.SAFE_THROW))
-                self.game.report(Outcome(OutcomeType.INACCURATE_PASS, player=self.passer, rolls=[self.roll]))
+                self.safe_throw_used = True 
+                
             else:
                 # Inaccurate pass
                 self.game.report(Outcome(OutcomeType.INACCURATE_PASS, player=self.passer, rolls=[self.roll]))
@@ -2158,6 +2160,7 @@ class PassAction(Procedure):
             self.reroll = None
             self.roll = None
             self.fumble = False
+            self.safe_throw_used = False 
             return False
 
         if self.fumble:
@@ -2169,9 +2172,13 @@ class PassAction(Procedure):
         if not self.dump_off:
             TurnoverIfPossessionLost(self.game, self.ball)
 
+        if self.safe_throw_used: 
+            return True 
+            
         self.ball.move_to(self.position)
         Scatter(self.game, self.ball, is_pass=True)
         return True
+
 
 
 class Pickup(Procedure):

--- a/ffai/core/procedure.py
+++ b/ffai/core/procedure.py
@@ -679,7 +679,7 @@ class Casualty(Procedure):
                         n=self.effect.name,
                         rolls=[self.roll]))
 
-            if self.player.team.state.apothecaries > 1:
+            if self.player.team.state.apothecaries > 0:
                 Apothecary(self.game, self.player, roll=self.roll, outcome=OutcomeType.CASUALTY,
                            casualty=self.casualty, effect=self.effect, inflictor=self.inflictor)
                 return True

--- a/tests/game/test_pass.py
+++ b/tests/game/test_pass.py
@@ -218,3 +218,33 @@ def test_pass_roll_inaccurate(pass_skill):
         assert not game.has_report_of_type(OutcomeType.ACCURATE_PASS)
         assert not game.has_report_of_type(OutcomeType.FUMBLE)
         assert not game.has_report_of_type(OutcomeType.SKILL_USED)
+        
+def test_pass_safe_throw(): 
+    game = get_game_turn()
+    team = game.get_agent_team(game.actor)
+    game.clear_board()
+    game.state.weather = WeatherType.NICE
+    game.state.teams[0].state.rerolls = 0
+    
+    passer = team.players[0]
+    passer.role.skills = [Skill.SAFE_THROW]
+    passer.role.ag = 3
+    game.put(passer, Square(2, 2))
+    game.get_ball().move_to(passer.position)
+    game.get_ball().is_carried = True
+    
+    catcher = team.players[1]
+    catcher_position = Square(passer.position.x + 12, passer.position.y + 0)
+    game.put(catcher, catcher_position)
+    
+    game.set_available_actions()
+    game.state.reports.clear() 
+
+    D6.fix_result(2)  # Fumble pass
+    
+    game.step(Action(ActionType.START_PASS, player=passer))
+    game.step(Action(ActionType.PASS, position=catcher_position ))
+    
+    assert game.has_report_of_type(OutcomeType.SKILL_USED)
+    assert not game.has_report_of_type(OutcomeType.FUMBLE)
+    assert game.get_ball_carrier() == passer 


### PR DESCRIPTION
Safe throw was implemented according so that a fumbled outcome was treated as inaccurate. This is wrong according to BB2016. This PR solves that and also fixes an obvious error regarding apothecary in the casualty procedure. 

![image](https://user-images.githubusercontent.com/31434035/95002212-c10b9e80-05d1-11eb-8834-aa36a7ae8137.png)

Sorry for the span with the previous PR that ended up being wrong. 

