### PR TITLE
on default server serves only on local host for security reasons

### DIFF
--- a/ffai/web/server.py
+++ b/ffai/web/server.py
@@ -141,7 +141,7 @@ def get_bots():
     return json.dumps(api.get_bots())
 
 
-def start_server(debug=False, use_reloader=False, port=5000, host="0.0.0.0"):
+def start_server(debug=False, use_reloader=False, port=5000, host="127.0.0.1"):
     
     # Change jinja notation to work with angularjs
     jinja_options = app.jinja_options.copy()


### PR DESCRIPTION
The default behaviour should be, that the server binds on localhost, i. e. 127.0.0.1 and not on all addresses 0.0.0.0 to not expose any possible vulnerabilities to the (local) network.